### PR TITLE
Update to use Debian bookworm and nut 2.8.0

### DIFF
--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -1,13 +1,11 @@
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 LABEL maintainer="ethitter"
-LABEL version="1.0"
-
-RUN echo "deb http://security.debian.org/ buster/updates main" >> /etc/apt/sources.list
+LABEL version="1.1"
 
 RUN apt-get update \
     && apt-get -y --no-install-recommends install \
-        nut=2.7.4-8 \
+    nut \
     && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Suggesting an update to the docker image to use the Debian bookworm branch which ships with the "newest" Nut version 2.8.0.

I needed this for output current on my APC UPS, just wanted to share it back.